### PR TITLE
Java not found outside "bin" folder

### DIFF
--- a/src/main/resources/devtool.bat
+++ b/src/main/resources/devtool.bat
@@ -16,7 +16,7 @@ set APP_HOME=%DIRNAME%..
 @rem Add default JVM options here. You can also use JAVA_OPTS and DEVTOOL_OPTS to pass JVM options to this script.
 set DEFAULT_JVM_OPTS=
 
-set JAVA_EXE="..\\jre\\bin\\java.exe"
+set JAVA_EXE="%DIRNAME%\\..\\jre\\bin\\java.exe"
 
 :init
 @rem Get command-line arguments, handling Windows variants


### PR DESCRIPTION
If DevTool in Windows is executed outside "bin" folder (when system environment PATH is used) it is not able to find Java. When absolute path is added to JAVA_EXE - it works.